### PR TITLE
Add computed fields to gql using computed fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,29 @@ Graphql api for storing clinical trials statuses
               id
               orgName
               orgType
+              lateReportCount
+              readyForReportCount
+              lateReportRate
               trialsByOrgId {
                 nodes {
                   id
                   completionDate
                   completionStatus
                   resultsReportDate
+                  isLate
+                  readyForReport
                 }
               }
             }
           }
         }
         ```
+# Updating schema file
+
+1) `npm install -g graphql-cli`
+
+2) Run with docker
+
+3) `graphql init`
+
+4) `graphql get-schema`

--- a/db/init/01-computed_aggregations.sql
+++ b/db/init/01-computed_aggregations.sql
@@ -1,0 +1,40 @@
+\connect clinical_trials_status;
+
+CREATE FUNCTION trials_status_schema.trials_ready_for_report(trial trials_status_schema.trials)
+RETURNS BOOLEAN as $$
+    SELECT
+    (trial.completion_date IS NOT NULL) AND
+    (trial.completion_date <= now() - INTERVAL '1 year');
+$$ language sql stable;
+
+CREATE FUNCTION trials_status_schema.trials_is_late(trial trials_status_schema.trials)
+RETURNS BOOLEAN as $$
+    SELECT
+    trials_status_schema.trials_ready_for_report(trial) AND
+    (
+        (trial.results_report_date IS NULL) OR
+        (trial.results_report_date - trial.completion_date >= INTERVAL '1 year')
+    );
+$$ language sql stable;
+
+CREATE FUNCTION trials_status_schema.institutions_late_report_count(institution trials_status_schema.institutions)
+RETURNS BIGINT as $$
+    SELECT COUNT(trial_table.id)
+    FROM trials_status_schema.trials as trial_table
+    WHERE trial_table.org_id = institution.id AND
+        trials_status_schema.trials_is_late(trial_table);
+$$ language sql stable;
+
+CREATE FUNCTION trials_status_schema.institutions_ready_for_report_count(institution trials_status_schema.institutions)
+RETURNS BIGINT as $$
+    SELECT COUNT(trial_table.id)
+    FROM trials_status_schema.trials as trial_table
+    WHERE trial_table.org_id = institution.id AND
+        trials_status_schema.trials_ready_for_report(trial_table);
+$$ language sql stable;
+
+CREATE FUNCTION trials_status_schema.institutions_late_report_rate(institution trials_status_schema.institutions)
+RETURNS FLOAT as $$
+    SELECT CAST(trials_status_schema.institutions_late_report_count(institution) AS FLOAT)
+     / trials_status_schema.institutions_ready_for_report_count(institution)
+$$ language sql stable;

--- a/db/init/99-test_data.sql
+++ b/db/init/99-test_data.sql
@@ -7,4 +7,6 @@ INSERT INTO trials_status_schema.institutions (org_name, org_type) VALUES
 INSERT INTO trials_status_schema.trials (trial_id, completion_date, completion_status, results_report_date, clinicaltrials_updated_at, org_id) VALUES
 ('11', '2017-10-01', 'Actual', NULL, '2019-01-01', 1),
 ('22', '2020-10-01', 'Projected', NULL, '2019-01-01', 1),
-('33', '2015-10-01', 'Actual', '2016-10-01', '2019-01-01', 2);
+('12', '2017-11-01', 'Actual', '2018-10-01', '2019-10-01', 1),
+('33', '2015-10-01', 'Actual', '2016-10-01', '2019-01-01', 2),
+('34', '2015-10-01', 'Actual', '2016-09-22', '2019-01-01', 2);

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,5 +1,12 @@
 # source: http://localhost:5000/graphql
-# timestamp: Sun Sep 08 2019 17:08:25 GMT-0500 (Central Daylight Time)
+# timestamp: Sun Sep 15 2019 11:59:43 GMT-0500 (Central Daylight Time)
+
+"""
+A signed eight-byte integer. The upper big integer values are greater than the
+max value for a JavaScript number. Therefore all big integers will be output as
+strings and not numbers.
+"""
+scalar BigInt
 
 """All input for the create `Institution` mutation."""
 input CreateInstitutionInput {
@@ -222,6 +229,9 @@ type Institution implements Node {
     """
     condition: TrialCondition
   ): TrialsConnection!
+  lateReportCount: BigInt
+  lateReportRate: Float
+  readyForReportCount: BigInt
 }
 
 """
@@ -530,6 +540,8 @@ type Trial implements Node {
 
   """Reads a single `Institution` that is related to this `Trial`."""
   institutionByOrgId: Institution
+  isLate: Boolean
+  readyForReport: Boolean
 }
 
 """


### PR DESCRIPTION
Intended functionality using [computed columns](https://www.graphile.org/postgraphile/computed-columns/):
Expose aggregations across institutions that return the late result rate by institution