### PR TITLE
Switch over to supporting an SQL scraper

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,12 @@
+# This is a development configuration. Change for production!
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=1234
+POSTGRES_DATABASE=clinical_trials_status
+GRAPHQL_PORT=5000
+GRAPHQL_HOST=0.0.0.0
+# Set to 86400 to do daily scrapes
+SECONDS_BETWEEN_SCRAPES=1
+
+# Set to "always" to have recurring scrapes
+# It's currently set to "no" for development, so the scraper only runs once
+RESTART=no

--- a/.env
+++ b/.env
@@ -20,4 +20,4 @@ DISABLE_MUTATIONS_FLAG=--disable-default-mutations
 SCRAPER_USE_SQL_FLAG=--use-sql
 
 # debug setting to limit the amount of scraping
-SCRAPER_MAX_ID=1000
+SCRAPER_MAX_ID=100

--- a/.env
+++ b/.env
@@ -4,9 +4,20 @@ POSTGRES_PASSWORD=1234
 POSTGRES_DATABASE=clinical_trials_status
 GRAPHQL_PORT=5000
 GRAPHQL_HOST=0.0.0.0
-# Set to 86400 to do daily scrapes
-SECONDS_BETWEEN_SCRAPES=1
 
+# these two flags go together
 # Set to "always" to have recurring scrapes
 # It's currently set to "no" for development, so the scraper only runs once
 RESTART=no
+# Set to 86400 to do daily scrapes
+SECONDS_BETWEEN_SCRAPES=1
+
+# These two flags go together. They:
+# 1. cause the scraper to write directly to the DB
+# 2. disable mutations in the GraphQL interface so it's safe to run the GraphQL
+# server publicly
+DISABLE_MUTATIONS_FLAG=--disable-default-mutations
+SCRAPER_USE_SQL_FLAG=--use-sql
+
+# debug setting to limit the amount of scraping
+SCRAPER_MAX_ID=1000

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # clinical-trials-status-store
+
 Graphql api for storing clinical trials statuses
 
-# Current testing
+## Current testing
 
 1) `cd clinical-trials-status-store`
 
@@ -33,7 +34,7 @@ Graphql api for storing clinical trials statuses
           }
         }
         ```
-# Updating schema file
+## Updating schema file
 
 1) `npm install -g graphql-cli`
 
@@ -42,3 +43,9 @@ Graphql api for storing clinical trials statuses
 3) `graphql init`
 
 4) `graphql get-schema`
+
+## Running in production
+
+Modify (but don't commit) the .env file to have better postgres password (if
+it's exposed) and make sure the restart behavior is configured to re-run the
+scraper at the desired interval.

--- a/db/init/00-database.sql
+++ b/db/init/00-database.sql
@@ -1,30 +1,27 @@
 CREATE DATABASE clinical_trials_status;
-
 \connect clinical_trials_status;
 
 CREATE SCHEMA trials_status_schema;
 
 CREATE TABLE trials_status_schema.institutions (
-    id SERIAL PRIMARY KEY,
-    org_name TEXT,
-    org_type TEXT,
-    created_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  id SERIAL UNIQUE,
+  org_name TEXT,
+  org_type TEXT DEFAULT '',
+  created_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (org_name, org_type)
 );
-COMMENT ON TABLE trials_status_schema.institutions IS
-'Institutions that run clinical trials.';
-
+COMMENT ON TABLE trials_status_schema.institutions IS 'Institutions that run clinical trials.';
 CREATE TABLE trials_status_schema.trials (
-    id TEXT PRIMARY KEY,
-    completion_date TIMESTAMP,
-    completion_status TEXT,
-    results_report_date TIMESTAMP,
-    is_delayed BOOLEAN,
-    contact_email TEXT,
-    clinicaltrials_updated_at TIMESTAMP,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    org_id INTEGER NOT NULL REFERENCES trials_status_schema.institutions(id)
+  id TEXT PRIMARY KEY,
+  completion_date TIMESTAMP,
+  completion_status TEXT,
+  results_report_date TIMESTAMP,
+  is_delayed BOOLEAN,
+  contact_email TEXT,
+  clinicaltrials_updated_at TIMESTAMP,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  org_id INTEGER NOT NULL REFERENCES trials_status_schema.institutions(id)
 );
-COMMENT ON TABLE trials_status_schema.trials IS
-'Trials from clinicaltrials.gov with their completion status.';
+COMMENT ON TABLE trials_status_schema.trials IS 'Trials from clinicaltrials.gov with their completion status.';

--- a/db/init/00-database.sql
+++ b/db/init/00-database.sql
@@ -6,7 +6,7 @@ CREATE SCHEMA trials_status_schema;
 CREATE TABLE trials_status_schema.institutions (
   id SERIAL UNIQUE,
   org_name TEXT,
-  org_type TEXT DEFAULT '',
+  org_type TEXT,
   created_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   updated_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (org_name, org_type)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
         "${GRAPHQL_PORT}",
         "--schema",
         "trials_status_schema",
+        "${DISABLE_MUTATIONS_FLAG}",
       ]
     links:
       - db
@@ -53,4 +54,6 @@ services:
       - GRAPHQL_HOST
       - GRAPHQL_PORT
       - SECONDS_BETWEEN_SCRAPES
+      - SCRAPER_USE_SQL_FLAG
+      - SCRAPER_MAX_ID
     restart: "${RESTART}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   db:
     container_name: psql
@@ -6,8 +6,8 @@ services:
     image: psql
     build:
       context: ./db
-#    volumes: this persists the db code locally
-#      - ./db/data/:/var/lib/postgresql/data
+    #    volumes: this persists the db code locally
+    #      - ./db/data/:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER
       - POSTGRES_PASSWORD
@@ -15,7 +15,7 @@ services:
     expose:
       - 5432
     ports:
-        - "127.0.0.1:5432:5432"
+      - "127.0.0.1:5432:5432"
   graphql:
     container_name: pgql
     restart: always
@@ -53,4 +53,4 @@ services:
       - GRAPHQL_HOST
       - GRAPHQL_PORT
       - SECONDS_BETWEEN_SCRAPES
-    restart: "no"
+    restart: "${RESTART}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,15 +9,11 @@ services:
 #    volumes: this persists the db code locally
 #      - ./db/data/:/var/lib/postgresql/data
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: 1234  # To be moved to environment file
-      POSTGRES_DATABASE: clinical_trials_status
-    expose:
-      - 5432
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD
+      - POSTGRES_DATABASE
     ports:
-      - 5432:5432
-    networks:
-      - psql-pgql
+        - "127.0.0.1:5432:5432"
   graphql:
     container_name: pgql
     restart: always
@@ -29,11 +25,30 @@ services:
     expose:
       - 5000
     ports:
-      - 5000:5000
-    command: ["postgraphile", "--cors", "--connection", $DATABASE_URL, "--host", "0.0.0.0", "--port", "5000", "--schema", "trials_status_schema"]
+      - "${HOST_IP:-127.0.0.1}:${GRAPHQL_PORT}:${GRAPHQL_PORT}"
+    command:
+      [
+        "--cors",
+        "--retry-on-init-fail",
+        "--connection",
+        "postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DATABASE}",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "${GRAPHQL_PORT}",
+        "--schema",
+        "trials_status_schema",
+      ]
     links:
       - db
-    networks:
-      - psql-pgql
-networks:
-  psql-pgql:
+  scraper:
+    container_name: scraper
+    # image: dstuck/clinical-trials-api-scraper:latest
+    build: ../clinical-trials-api-scraper
+    depends_on:
+      - graphql
+    environment:
+      - GRAPHQL_HOST
+      - GRAPHQL_PORT
+      - SECONDS_BETWEEN_SCRAPES
+    restart: "no"


### PR DESCRIPTION
- Make changes that support a scraper that writes directly to the DB. This allows the GraphQL API to be limited to read-only and exposed publicly without security concerns.
- Make the setup more configurable via env variables, and add a `.env` file with sane defaults for development
- Add a primary key for the institutions based on the name & type